### PR TITLE
Bugfix/remove s3 acl

### DIFF
--- a/GeminiAPI/api_request.py
+++ b/GeminiAPI/api_request.py
@@ -112,7 +112,6 @@ def upload_image_to_s3(local_file_path, bucket_name, s3_file_name=None): #Upload
             Bucket=bucket_name,
             Key=s3_file_name,
             ExtraArgs={
-                'ACL': 'public-read',  # Make the object publicly readable
                 'ContentType': 'image/jpeg'  # Set appropriate MIME type
             }
         )


### PR DESCRIPTION
Removed line 115 from api_request.py because it was using the deprecated ACL feature for S3 bucket